### PR TITLE
Break up abstract and description

### DIFF
--- a/content/speaker/joel-quenneville.md
+++ b/content/speaker/joel-quenneville.md
@@ -11,7 +11,7 @@ Dive into Elm’s random generators on a quest to build a historically accurate
 Roman random name generator for the goddess Juno, based on a series of dependent
 and independent constraints.
 
-<!--more-->
+---
 
 You are an ancient software engineer. Juno, the Roman goddess of marriage and
 fertility, surprises you by walking into your office and offering you an


### PR DESCRIPTION
The abstract is a one-sentence summary of the description. It reads a
bit strange to see both of them combined together. This adds a line
between the two to emphasize the distinction.

Not sure how we plan on eventually displaying these visually on the
website. Will the abstract/description be separate? Are we trying to
combine the two into a single description?
